### PR TITLE
Inverted bending direction

### DIFF
--- a/PadmeMC/EVeto/include/EVetoGeometry.hh
+++ b/PadmeMC/EVeto/include/EVetoGeometry.hh
@@ -32,7 +32,7 @@ protected:
 public:
 
   // Position of center of EVeto box
-  G4double GetEVetoPosX() { return fEVetoInnerFacePosX-0.5*GetEVetoSizeX(); }
+  G4double GetEVetoPosX() { return fEVetoInnerFacePosX+0.5*GetEVetoSizeX(); }
   G4double GetEVetoPosY() { return 0.*cm; }
   G4double GetEVetoPosZ() { return fEVetoFrontFacePosZ+0.5*GetEVetoSizeZ(); }
 

--- a/PadmeMC/EVeto/src/EVetoGeometry.cc
+++ b/PadmeMC/EVeto/src/EVetoGeometry.cc
@@ -30,7 +30,7 @@ EVetoGeometry::EVetoGeometry()
   fFingerNominalSizeZ =  1.0*cm;
 
   //fFingerRotX = 0.*deg;
-  fFingerRotY = 10.*deg;
+  fFingerRotY = -10.*deg;
   //fFingerRotZ = 0.*deg;
 
   fSupportGap = 0.1*mm;
@@ -39,7 +39,7 @@ EVetoGeometry::EVetoGeometry()
   fSupportNominalSizeY =   0.5*cm;
   fSupportNominalSizeZ = 100.0*cm;
 
-  fEVetoInnerFacePosX = -20.*cm;
+  fEVetoInnerFacePosX = 20.*cm;
 
   fEVetoFrontFacePosZ = -50.*cm; // Start at front face of yoke
 

--- a/PadmeMC/HEPVeto/src/HEPVetoGeometry.cc
+++ b/PadmeMC/HEPVeto/src/HEPVetoGeometry.cc
@@ -28,24 +28,20 @@ HEPVetoGeometry::HEPVetoGeometry()
 
   fFingerGap = 0.1*mm;
 
-  // Position of center of HEPVeto relative to center of magnet yoke
-  //fHEPVetoCenterPosX = 120.*cm;
-  //fHEPVetoCenterPosY =   0.*cm;
-  //fHEPVetoCenterPosZ = 250.*cm;
-
   // Size of HEPVeto box
   fHEPVetoSizeX = 2.*cm;
   fHEPVetoSizeY = fFingerNominalSizeY;
   fHEPVetoSizeZ = 60.*cm;
 
   // Position of center of HEPVeto inner face relative to center of magnet yoke
-  fHEPVetoInnerFacePosX =  93.*cm;
+  fHEPVetoInnerFacePosX = -93.*cm;
   fHEPVetoInnerFacePosY =   0.*cm;
   fHEPVetoInnerFacePosZ = 250.*cm;
 
-  fHEPVetoRotX = 0.   *rad;
-  fHEPVetoRotY = 0.977*rad; // ~56deg (i.e. 90deg-34deg, see PADME drawings)
-  fHEPVetoRotZ = 0.   *rad;
+  fHEPVetoRotX =  0.   *rad;
+  //fHEPVetoRotY = 0.977*rad; // ~56deg (i.e. 90deg-34deg, see PADME drawings)
+  fHEPVetoRotY = -0.977*rad; // ~-56deg (i.e. -90deg+34deg, see PADME drawings)
+  fHEPVetoRotZ =  0.   *rad;
 
   fHEPVetoSensitiveDetectorName = "HEPVetoSD";
 

--- a/PadmeMC/Magnet/src/MagnetGeometry.cc
+++ b/PadmeMC/Magnet/src/MagnetGeometry.cc
@@ -59,7 +59,7 @@ MagnetGeometry::MagnetGeometry()
 
   fYokeFrontFacePosZ = -0.5*fYokeSizeZ; // Center of magnet yoke = global reference point
 
-  fMagneticFieldConstantValue = 0.55*tesla;
+  fMagneticFieldConstantValue = -0.55*tesla;
 
   fMagnetSensitiveDetectorName = "MagnetSD";
 

--- a/PadmeMC/Magnet/src/MagnetMessenger.cc
+++ b/PadmeMC/Magnet/src/MagnetMessenger.cc
@@ -52,7 +52,7 @@ MagnetMessenger::MagnetMessenger(MagnetStructure* mag)
   fSetMagneticFieldConstantValueCmd = new G4UIcommand("/Detector/Magnet/MagneticFieldConstantValue",this);
   fSetMagneticFieldConstantValueCmd->SetGuidance("Set constant (max) value of magnetic field in tesla.");
   G4UIparameter* mfCVParameter = new G4UIparameter("CV",'d',false);
-  mfCVParameter->SetParameterRange("CV >= 0. && CV <= 1.");
+  mfCVParameter->SetParameterRange("CV >= -1.5 && CV <= 1.5");
   fSetMagneticFieldConstantValueCmd->SetParameter(mfCVParameter);
   fSetMagneticFieldConstantValueCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
 

--- a/PadmeMC/Magnet/src/MagneticFieldMap.cc
+++ b/PadmeMC/Magnet/src/MagneticFieldMap.cc
@@ -8,7 +8,7 @@ MagneticFieldMap::MagneticFieldMap()
 {
 
   // Default value: can be changed with set method
-  fConstantMagneticField = 0.32*tesla;
+  fConstantMagneticField = -0.55*tesla; // WARNING: not used! Real default is set in MagnetGeometry.cc
 
   fConstantMagneticFieldXmin = -26.0*cm;
   fConstantMagneticFieldXmax =  26.0*cm;

--- a/PadmeMC/PVeto/include/PVetoGeometry.hh
+++ b/PadmeMC/PVeto/include/PVetoGeometry.hh
@@ -32,7 +32,7 @@ protected:
 public:
 
   // Position of center of PVeto box
-  G4double GetPVetoPosX() { return fPVetoInnerFacePosX+0.5*GetPVetoSizeX(); }
+  G4double GetPVetoPosX() { return fPVetoInnerFacePosX-0.5*GetPVetoSizeX(); }
   G4double GetPVetoPosY() { return 0.*cm; }
   G4double GetPVetoPosZ() { return fPVetoFrontFacePosZ+0.5*GetPVetoSizeZ(); }
 

--- a/PadmeMC/PVeto/src/PVetoGeometry.cc
+++ b/PadmeMC/PVeto/src/PVetoGeometry.cc
@@ -30,7 +30,7 @@ PVetoGeometry::PVetoGeometry()
   fFingerNominalSizeZ =  1.0*cm;
 
   //fFingerRotX = 0.*deg;
-  fFingerRotY = -10.*deg;
+  fFingerRotY = 10.*deg;
   //fFingerRotZ = 0.*deg;
 
   fSupportGap = 0.1*mm;
@@ -39,7 +39,7 @@ PVetoGeometry::PVetoGeometry()
   fSupportNominalSizeY =   0.5*cm;
   fSupportNominalSizeZ = 100.0*cm;
 
-  fPVetoInnerFacePosX =  20.*cm;
+  fPVetoInnerFacePosX =  -20.*cm;
 
   fPVetoFrontFacePosZ = -50.*cm; // Start at front face of yoke
 

--- a/PadmeMC/TPix/src/TPixGeometry.cc
+++ b/PadmeMC/TPix/src/TPixGeometry.cc
@@ -23,20 +23,20 @@ TPixGeometry::TPixGeometry()
   fTPixNRows = 2;
   fTPixNCols = 5;
 
-  fChipNominalSizeX =  0.1*mm; // Thickness
+  fChipNominalSizeX =   0.10*mm; // Thickness
   fChipNominalSizeY =  14.08*mm; // 256 pixels of 55um each
   fChipNominalSizeZ =  14.08*mm; // 256 pixels of 55um each
 
   fChipGap = 0.01*mm;
 
   // Position of center of TPix relative to center of magnet yoke
-  fTPixCenterPosX =  92.*cm;
+  fTPixCenterPosX =  -92.*cm;
   fTPixCenterPosY =   0.*cm;
   fTPixCenterPosZ = 256.*cm;
 
-  fTPixRotX = 0.   *rad;
-  fTPixRotY = 0.977*rad; // ~56deg (i.e. 90deg-34deg, see PADME drawings)
-  fTPixRotZ = 0.   *rad;
+  fTPixRotX =  0.   *rad;
+  fTPixRotY = -0.977*rad; // ~-56deg (i.e. -90deg+34deg, see PADME drawings)
+  fTPixRotZ =  0.   *rad;
 
   fTPixSensitiveDetectorName = "TPixSD";
 

--- a/PadmeMC/vis.mac
+++ b/PadmeMC/vis.mac
@@ -5,7 +5,7 @@
 #
 /control/verbose 1
 /run/verbose 1
-/tracking/verbose 1
+#/tracking/verbose 1
 
 # Output root file
 #/output/fileName pippo.root
@@ -45,7 +45,7 @@
 #/Detector/Magnet/SetMagneticVolumeInvisible
 #/Detector/Magnet/EnableMagneticField
 #/Detector/Magnet/DisableMagneticField
-#/Detector/Magnet/MagneticFieldConstantValue 0.55
+#/Detector/Magnet/MagneticFieldConstantValue -0.55
 
 #/Detector/ECal/NRows 29
 #/Detector/ECal/NCols 29
@@ -65,25 +65,25 @@
 #/Detector/LAV/FrontFaceZ -75.
 
 #/Detector/PVeto/FrontFaceZ -50.
-#/Detector/PVeto/InnerFaceX 20.
+#/Detector/PVeto/InnerFaceX -20.
 #/Detector/PVeto/NFingers 96
 #/Detector/PVeto/FingerSize 1.
-#/Detector/PVeto/FingerLength 18.
+#/Detector/PVeto/FingerLength 16.
 
 #/Detector/EVeto/FrontFaceZ -50.
-#/Detector/EVeto/InnerFaceX -20.
+#/Detector/EVeto/InnerFaceX  20.
 #/Detector/EVeto/NFingers 96
 #/Detector/EVeto/FingerSize 1.
-#/Detector/EVeto/FingerLength 18.
+#/Detector/EVeto/FingerLength 16.
 
 #/Detector/HEPVeto/NFingers 50
 #/Detector/HEPVeto/FingerSize 1.
-#/Detector/HEPVeto/FingerLength 18.
-#/Detector/HEPVeto/PositionX 93.
+#/Detector/HEPVeto/FingerLength 20.
+#/Detector/HEPVeto/PositionX -93.
 #/Detector/HEPVeto/PositionY 0.      # Disabled
 #/Detector/HEPVeto/PositionZ 250.
 #/Detector/HEPVeto/RotationX 0.      # Disabled
-#/Detector/HEPVeto/RotationY 0.977
+#/Detector/HEPVeto/RotationY -0.977
 #/Detector/HEPVeto/RotationZ 0.      # Disabled
 
 #/Detector/TDump/TargetRadius 3.5
@@ -92,11 +92,11 @@
 #/Detector/TDump/FrontFaceZ -180.
 
 #/Detector/TPix/NColumns 5
-#/Detector/TPix/PositionX 92.
+#/Detector/TPix/PositionX -92.
 #/Detector/TPix/PositionY 0.      # Disabled
 #/Detector/TPix/PositionZ 256.
 #/Detector/TPix/RotationX 0.      # Disabled
-#/Detector/TPix/RotationY 0.977
+#/Detector/TPix/RotationY -0.977
 #/Detector/TPix/RotationZ 0.      # Disabled
 
 ### Setup for beam deflection tests
@@ -105,6 +105,7 @@
 #/Detector/TPix/PositionX 70.
 #/Detector/TPix/PositionZ 230.
 #/Detector/TPix/RotationY 1.570796
+
 #/beam/n_e+_per_bunch 1
 #/beam/n_e+_poisson_on false
 #/beam/bunch_structure_on false
@@ -114,7 +115,7 @@
 ### Test for target energy loss
 #/Detector/DisableSubDetector Target
 ### Test for high energy/high field setup
-#/Detector/Magnet/MagneticFieldConstantValue 0.8
+#/Detector/Magnet/MagneticFieldConstantValue -0.8
 #/beam/momentum 1. GeV
 
 # Beam setup
@@ -125,21 +126,22 @@
 #/beam/3g_file events_ee-3g-550MeV-1M.txt
 
 # Primary positrons setup
+#/beam/n_e+_per_bunch 5000
 #/beam/n_e+_poisson_on false
-#/beam/bunch_structure_on false
+#/beam/bunch_structure_on true
 #/beam/bunch_time_length 40. ns
 #/beam/ubunch_time_length 150 ps
 #/beam/ubunch_time_delay 350 ps
 #/beam/position_x 0. cm
 #/beam/position_y 0. cm
-#/beam/position_spread_on false
-#/beam/position_x_spread 0.7 mm
-#/beam/position_y_spread 0.7 mm
+#/beam/position_spread_on true
+#/beam/position_x_spread 1. mm
+#/beam/position_y_spread 1. mm
 #/beam/momentum 550. MeV
-#/beam/momentum_spread_on false
+#/beam/momentum_spread_on true
 #/beam/momentum_spread 55. MeV
 #/beam/direction 0. 0. 1.
-#/beam/emittance_on false
+#/beam/emittance_on true
 #/beam/emittance_x 0.001
 #/beam/emittance_y 0.001
 


### PR DESCRIPTION
This branch iplements the inversion of the bending direction.
Magnetic field is inverted, EVeto and PVeto are swapped, HEPVeto and TPix moved to the opposit side of the ECal.
vis.mac defaults have been updated accordingly.